### PR TITLE
Remove CRC 1.0 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 AbstractGPs = "0.3"
-ChainRulesCore = "0.10, 1"
+ChainRulesCore = "0.10"
 Distributions = "0.25"
 FastGaussQuadrature = "0.4"
 FillArrays = "0.12"


### PR DESCRIPTION
Appears to break AD. Will probably just need to define some custom adjoints, but it's easiest to just remove it for now.